### PR TITLE
Kinto AA v6 address

### DIFF
--- a/user-ops-indexer/user-ops-indexer-logic/src/indexer/v06/mod.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/indexer/v06/mod.rs
@@ -19,7 +19,7 @@ use lazy_static::lazy_static;
 use std::ops::Div;
 
 lazy_static! {
-    static ref ENTRYPOINT: ethers::types::Address = "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+    static ref ENTRYPOINT: ethers::types::Address = "0x2843C269D2a64eCfA63548E8B3Fc0FD23B7F70cb"
         .parse()
         .unwrap();
 }


### PR DESCRIPTION
<img width="447" alt="image" src="https://github.com/user-attachments/assets/d0dfa09f-554b-4331-9207-97460ff12114">


001138754299.dkr.ecr.us-west-2.amazonaws.com/blockscout-user-ops-indexer   3.3.2-kinto       316710cae8b9   45 hours ago        300MB